### PR TITLE
Added missing module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "browser-sync": "^2.7.12",
     "del": "^1.2.0",
     "gulp": "^3.9.0",
+    "gulp-autoprefixer": "^2.3.1",
     "gulp-cache": "^0.2.10",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.3.0",
     "gulp-minify-css": "^1.2.0",
     "gulp-sass": "^2.0.1",
+    "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
     "gulp-useref": "^1.2.0",
     "run-sequence": "^1.1.2"


### PR DESCRIPTION
autoprefixer and sourcemaps module are missing from package file so were giving error upon running Gulp command. So I have added
