### PR TITLE
Updated order of default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('clean:dist', function() {
 // ---------------
 
 gulp.task('default', function(callback) {
-  runSequence(['sass', 'browserSync', 'watch'],
+  runSequence(['sass', 'browserSync'] 'watch',
     callback
   )
 })


### PR DESCRIPTION
sass and browserSync tasks should be finished before watch is started, so the CSS will already be the latest whenever we run a Gulp command.